### PR TITLE
Changed url for psp predict kernels

### DIFF
--- a/astrospice/net/reg.py
+++ b/astrospice/net/reg.py
@@ -8,13 +8,12 @@ from collections import defaultdict
 from dataclasses import dataclass
 
 import astropy.time
+import parfive
+from astropy.table import Table, vstack
+from astropy.time import Time
 
-import parfive  # noqa: E402
-from astropy.table import Table, vstack  # noqa: E402
-from astropy.time import Time  # noqa: E402
-
-from astrospice.config import get_cache_dir  # noqa: E402
-from astrospice.kernel import Kernel  # noqa: E402
+from astrospice.config import get_cache_dir
+from astrospice.kernel import Kernel
 
 __all__ = ['KernelRegistry', 'RemoteKernel', 'RemoteKernelsBase', 'registry']
 

--- a/astrospice/net/reg.py
+++ b/astrospice/net/reg.py
@@ -4,17 +4,11 @@
 A registry of SPICE kernels for various missions.
 """
 import abc
-import os
 from collections import defaultdict
 from dataclasses import dataclass
 
 import astropy.time
 
-# disable splitting the download since psp predict kernel server does not give a content-length in the response
-# this will not be necessary if parfive is changed
-
-
-os.environ["PARFIVE_DISABLE_RANGE"] = "1"
 import parfive  # noqa: E402
 from astropy.table import Table, vstack  # noqa: E402
 from astropy.time import Time  # noqa: E402

--- a/astrospice/net/reg.py
+++ b/astrospice/net/reg.py
@@ -4,16 +4,23 @@
 A registry of SPICE kernels for various missions.
 """
 import abc
+import os
 from collections import defaultdict
 from dataclasses import dataclass
 
 import astropy.time
-import parfive
-from astropy.table import Table, vstack
-from astropy.time import Time
 
-from astrospice.config import get_cache_dir
-from astrospice.kernel import Kernel
+# disable splitting the download since psp predict kernel server does not give a content-length in the response
+# this will not be necessary if parfive is changed
+
+
+os.environ["PARFIVE_DISABLE_RANGE"] = "1"
+import parfive  # noqa: E402
+from astropy.table import Table, vstack  # noqa: E402
+from astropy.time import Time  # noqa: E402
+
+from astrospice.config import get_cache_dir  # noqa: E402
+from astrospice.kernel import Kernel  # noqa: E402
 
 __all__ = ['KernelRegistry', 'RemoteKernel', 'RemoteKernelsBase', 'registry']
 

--- a/astrospice/net/sources/psp.py
+++ b/astrospice/net/sources/psp.py
@@ -18,19 +18,18 @@ class PSPPredict(RemoteKernelsBase):
         -------
         list[RemoteKernel]
         """
-        page = urlopen('https://sppgway.jhuapl.edu/lpredict_ephem')
+        page = urlopen('https://spdf.gsfc.nasa.gov/pub/data/psp/ephemeris/spice/Long_Term_Predicted_Ephemeris/')
         soup = BeautifulSoup(page, 'html.parser')
 
         kernel_urls = []
         for link in soup.find_all('a'):
             href = link.get('href')
-            if href is not None and href.startswith('/MOC/ephemerides//'):
+            if href is not None and href.startswith('spp'):
                 fname = href.split('/')[-1]
                 matches = self.matches(fname)
                 if matches:
                     kernel_urls.append(
-                        RemoteKernel(f'https://sppgway.jhuapl.edu/{href}',
-                                     *matches[1:]))
+                        RemoteKernel(f'https://spdf.gsfc.nasa.gov/pub/data/psp/ephemeris/spice/Long_Term_Predicted_Ephemeris/{href}', *matches[1:]))
 
         return kernel_urls
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ setup_requires = setuptools_scm
 install_requires =
     astropy
     bs4
-    parfive
+    parfive>=2
     spiceypy
 
 


### PR DESCRIPTION
The old url https://sppgway.jhuapl.edu/lpredict_ephem no longer has the long term ephemeris files, so I have pointed astrospice to https://spdf.gsfc.nasa.gov/pub/data/psp/ephemeris/spice/Long_Term_Predicted_Ephemeris/ instead